### PR TITLE
Switched from using profile.admin to tell if a user is an admin

### DIFF
--- a/client/admin_login.coffee
+++ b/client/admin_login.coffee
@@ -1,6 +1,8 @@
+admin_user_exists = () -> Houston._admins.find().count() > 0
+
 Template._houston_login.helpers(
   logged_in: -> Meteor.user()
-  admin_user_exists: -> Meteor.users.findOne 'profile.admin': true
+  admin_user_exists: -> admin_user_exists()
 )
 
 Template._houston_login.events(
@@ -16,15 +18,14 @@ Template._houston_login.events(
       else
         Houston._go 'home'
 
-    if Meteor.users.findOne('profile.admin': true)
+    if admin_user_exists()
       Meteor.loginWithPassword email, password, afterLogin
     else
       Accounts.createUser {
         email: $('input[name="email"]').val()
         password: $('input[name="password"]').val()
-        profile:
-          admin: true
       }, afterLogin
+      Houston._call('make_admin', Meteor.userId())
 
   'click .houston-logout': (e) ->
     e.preventDefault()

--- a/client/router.coffee
+++ b/client/router.coffee
@@ -1,11 +1,16 @@
-Meteor.subscribe '_houston'
-Meteor.subscribe '_houston_adminUser'
-
 window.Houston ?= {}
+
+Houston._houstonize = (name) -> "_houston_#{name}"
+
+Houston._subscribe = (name) -> Meteor.subscribe Houston._houstonize name
+
+Houston._subscribe 'collections'
+Houston._subscribe 'admin_user'
+
 
 setup_collection = (collection_name, document_id) ->
   Houston._page_length = 20
-  subscription_name = "_houston_#{collection_name}"
+  subscription_name = Houston._houstonize collection_name
   collection = Houston._get_collection(collection_name)
   filter = if document_id
     # Sometimes you can lookup with _id being a string, sometimes not
@@ -21,8 +26,6 @@ setup_collection = (collection_name, document_id) ->
       Houston._page_length
   Houston._session('collection_name', collection_name)
   return [collection, Houston._paginated_subscription]
-
-Houston._houstonize = (name) -> "_houston_#{name}"
 
 Houston._houstonize_route = (name) -> Houston._houstonize(name)[1..]
 
@@ -66,7 +69,7 @@ Router.map ->
 
 mustBeAdmin = ->
   unless Meteor.loggingIn() # don't check for admin user until ready
-    unless Meteor.user()?.profile.admin
+    unless Houston._user_is_admin Meteor.userId()
       @stop()
       Houston._go 'login'
 

--- a/lib/collections.coffee
+++ b/lib/collections.coffee
@@ -4,4 +4,9 @@ root.Houston ?= {}
 
 Houston._collections ?= {}
 
-Houston._collections.collections = new Meteor.Collection("houston_")
+Houston._collections.collections = new Meteor.Collection('houston_collections')
+
+Houston._admins = new Meteor.Collection('houston_admins')
+
+Houston._user_is_admin = (id) ->
+  return id? and Houston._admins.findOne user_id: id


### PR DESCRIPTION
I decided to make a houston_admins collection instead of a houston_settings collection or a universal houston collection, because I don't see a downside to separating our collections over having on monolithic one. Also, this will easily allow for future versions of Houston to have multiple admins with different permissions.

Closes #44 
