### PR TITLE
When a new user claims admin, send them to home page once the claim is done

### DIFF
--- a/client/admin_login.coffee
+++ b/client/admin_login.coffee
@@ -32,8 +32,9 @@ Template._houston_login.events(
     Meteor.logout()
 
   'click .become-houston-admin': (e) ->
-    Houston._call('make_admin', Meteor.userId())
     e.preventDefault()
+    Houston._call('make_admin', Meteor.userId())
+    Houston._go 'home'
 )
 
 Template._houston_login.rendered = ->


### PR DESCRIPTION
the 'claim admin' case now has same behavior as log in / create new admin
