### PR TITLE
notice to refresh page on first-time login

### DIFF
--- a/client/db_view.coffee
+++ b/client/db_view.coffee
@@ -2,6 +2,9 @@ Template._houston_db_view.helpers
   collections: -> Houston._session('collections')
   num_of_records: -> Houston._collections.collections.findOne({name: @name}).count
 
+Template._houston_db_view.events
+  # trigger meteor session invalidation, definitely a hack
+  "click #refresh": -> window.location.reload()
 
 Template._houston_db_view.rendered = ->
   Houston._session('field_selectors', {})

--- a/client/db_view.html
+++ b/client/db_view.html
@@ -8,6 +8,9 @@
         <ul class="breadcrumb">
           <li class="active">Home</li>
         </ul>
+        {{# unless collections }}
+          <p class="lead">If this is your first time using Houston, you may need to <a id="refresh" class="btn btn-large btn-warning">Refresh this page</a></p>
+        {{/unless}}
         <table class='table table-bordered table-striped'>
           <thead>
             <tr>


### PR DESCRIPTION
When we have a new admin, we aren't getting the collections by default since the publish function still doesn't know the user is an admin (not reactive).

A longer-term solution would be to update both the user admin shown collections given whether the current user is houston_admins, but for now let's just ask the user to refresh.  Not in love with this solution but it works.
