### PR TITLE
bug exists if a top-level object is undefined

### DIFF
--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -72,7 +72,7 @@ sync_collections = ->
           new_collection = new Meteor.Collection(name)
         catch e
           for key, value of root
-            if name == value._name # TODO here - typecheck also?
+            if name == value?._name # TODO here - typecheck also?
               new_collection = value
 
         if new_collection?  # found it!


### PR DESCRIPTION
To replicate:

`window["hi"] = undefined;`
sync_collections()
