### PR TITLE
Fixed issue where houston was blocking a 404

### DIFF
--- a/client/router.coffee
+++ b/client/router.coffee
@@ -121,6 +121,6 @@ onRouteNotFound = Router.onRouteNotFound
 Router.onRouteNotFound = (args...) ->
   non_houston_routes = _.filter(Router.routes, (route) -> route.name.indexOf('houston_') != 0)
   if non_houston_routes.length > 0
-    onRouteNotFound(args...)
+    onRouteNotFound.apply Router, args
   else
     console.log "Note: Houston is suppressing Iron-Router errors because we don't think you are using it."


### PR DESCRIPTION
template from rendering.  This is because there was no `Router`
instance in the calling context of `onRouteNotFound`.  It was applying
the function to `null`.
