### PR TITLE
Blaze 0.8.0 fix

### DIFF
--- a/client/collection_view.html
+++ b/client/collection_view.html
@@ -76,8 +76,8 @@
                         {{/each}}
                     </form>
                 </div>
-            </div>
-            {{/if}}
+          </div>
         </div>
+        {{/if}}
     </div>
 </template>


### PR DESCRIPTION
Makes collection_view.html proper html so Blaze 0.8.0 can use it. An update on #142.

Fixes #146.
Fixes #141.
