### PR TITLE
Added ability to send in data from a Houston subscription to a custom template.

### DIFF
--- a/client/router.coffee
+++ b/client/router.coffee
@@ -53,7 +53,32 @@ Router.map ->
   houston_route 'custom_template',
     path: '/admin/:template'
     template: 'custom_template_view'
-    data: -> this.params
+    data: ->
+      # The subscriptions sent to this template
+      @subscriptions = []
+
+      # The menu item corresponding to this URL
+      customTemplateMenuItem = null
+
+      # Find the menu item corresponding to this URL
+      for menuItem in Houston.menu._menu_items
+        menuItemPath = Houston._houstonize_custom_template_path menuItem.use
+        if menuItemPath == this.path
+          customTemplateMenuItem = menuItem
+          break
+
+      # For each collection we need to subscribe to, subscribe and save in 
+      # list.
+      for collectionName in customTemplateMenuItem.subscribedCollections
+        [subscriptionName, subscription] = setup_collection(collectionName)
+        @subscriptions.push(subscription)
+
+      @params.subscriptions = @subscriptions
+
+      @params
+
+    waitOn: -> @subscriptions
+
 
   houston_route 'change_password',
     path: '/admin/password',

--- a/lib/menu.coffee
+++ b/lib/menu.coffee
@@ -17,7 +17,13 @@ Houston.menu._process_item = (item) ->
   if item.type is 'link'
     item.path = item.use
   else if item.type is 'template'
-    item.path = "/admin/#{item.use}"
+    item.path = Houston._houstonize_custom_template_path item.use
+
+    if item.subscribedCollections
+      if !_.isArray(item.subscribedCollections)
+        throw new Meteor.Error 400, 'subscribedCollections must be an array'
+    else
+      item.subscribedCollections = []
 
   return item
 

--- a/lib/shared.coffee
+++ b/lib/shared.coffee
@@ -30,3 +30,5 @@ Houston._get_fields = (documents) ->
 
 Houston._get_field_names = (documents) ->
   _.pluck(Houston._get_fields(documents), 'name')
+
+Houston._houstonize_custom_template_path = (name) -> "/admin/#{name}"


### PR DESCRIPTION
Not sure if this is how y'all would handle it.  Just my crack at it, and it seems to work for my application.  Addresses issue #177.  Haven't yet taken a look at manipulating data.

Usage:

``` javascript
Houston.menu({
  'type': 'template',
  'use': 'signup_admin',
  'title': 'InviteUsers',
  'subscribedCollections': ['SignedUpUsers']
});
```

A bit of a weird method, `Houston._houstonize_custom_template_path` just stores the way the path is created.  I had to do this because in the `data` callback, the menu items don't yet have the `path` set when the browser is refreshed from the custom template URL itself.  So the path needs to be recalculated there, unless it is ensured to have happened beforehand.
