### PR TITLE
Call @ready when publishing to support spiderable

### DIFF
--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -111,7 +111,9 @@ Meteor.methods
 
 # publish our analysis of the app's collections
 Houston._publish 'collections', ->
-  return unless Houston._user_is_admin @userId
+  unless Houston._user_is_admin @userId
+    @ready()
+    return
   Houston._collections.collections.find()
 
 # TODO address inherent security issue


### PR DESCRIPTION
Publish calls must either return a collection or call @ready to maintain
compatibility with the `spiderable` package:
http://docs.meteor.com/#spiderable

Fixes issues #170 and #130.
