### PR TITLE
Make sure Houston._setup_collection_methods only run server-side. Fixes ...

### DIFF
--- a/lib/methods.coffee
+++ b/lib/methods.coffee
@@ -1,5 +1,6 @@
 # shared meteor methods
 Houston._setup_collection_methods = (collection) ->
+  return  unless Meteor.isServer
   name = collection._name
   methods = {}
   methods[Houston._houstonize "#{name}_insert"] = (doc) ->


### PR DESCRIPTION
...#239

After taking a better look at the code, it seems like my suspicions were right. This is probably because some of the APIs need to be shared through globals. My 2 cents is that setup collections should be called once anyway (when the server spins up), but that's for the future. 

For now, this works.
