### PR TITLE
Workaround for pagination bug

### DIFF
--- a/client/router.coffee
+++ b/client/router.coffee
@@ -6,7 +6,7 @@ Houston._subscribe = (name) -> Meteor.subscribe Houston._houstonize name
 Houston._subscribe_to_collections()
 
 setup_collection = (collection_name, document_id) ->
-  Houston._page_length = 20
+  Houston._page_length = 9999999
   subscription_name = Houston._houstonize collection_name
   filter = if document_id
     # Sometimes you can lookup with _id being a string, sometimes not


### PR DESCRIPTION
Since pagination doesn't work anymore, i think a dirty workaround like this is the best thing to do until somebody more competent than me is able to fix the thing.  
(Setting pagination limit to 9999999 instead of 20)  
Of course, this will have to be reverted once the right fixes are made