### PR TITLE
Adding dependency on underscore package, fixes #325

### DIFF
--- a/package.js
+++ b/package.js
@@ -20,6 +20,7 @@ Package.on_use(function(api) {
   api.use('templating@1.0.0', 'client');  // ?optional
   api.use('check@1.0.0', ['client', 'server']);
   api.use('spacebars@1.0.0', 'client');
+  api.use('underscore@1.0.4', ['client', 'server']);
 
   //////////////////////////////////////////////////////////////////
   // Third-party package dependencies


### PR DESCRIPTION
When Houston is used within another package, its dependency on underscore is unmet.

Many projects create feature packages. These packages are typically dependent on a lib or core package that includes all the Meteor base packages. If Houston is included in a feature package, it doesn't know about the core/lib package, so it should ensure all of its Meteor core dependencies are explicit.